### PR TITLE
调整DialogManager使得popup上面可以再show

### DIFF
--- a/MornUILib/src/morn/core/managers/DialogManager.as
+++ b/MornUILib/src/morn/core/managers/DialogManager.as
@@ -4,12 +4,12 @@
  */
 package morn.core.managers {
 	import flash.display.Bitmap;
-import flash.display.DisplayObject;
-import flash.display.Sprite;
+    import flash.display.DisplayObject;
+    import flash.display.Sprite;
 	import flash.events.Event;
-import flash.utils.Dictionary;
+    import flash.utils.Dictionary;
 
-import morn.core.components.Box;
+    import morn.core.components.Box;
 	import morn.core.components.Dialog;
 	import morn.core.utils.ObjectUtils;
 


### PR DESCRIPTION
修改目标是让模式窗口（popup）上可以再叠加非模式窗口（show）。
修改后，所有的Dialog都会被addChild到_box中，包括_maskBg。之前的_mask被去除。
模式窗口和非模式窗口被分别保存到_show和_popup这个两个Dictionary。为避免内存问题这两个Dictionary开启了weakKeys。

另外，DialogManager的onResize处理方式（直接设置_box尺寸）会导致窗口舞台缩放时给莫名其妙拉大，所以我去除了这种粗暴的直接设置_box尺寸的方式。我觉得舞台内容的缩放交给stage.scalemode控制可以的。
